### PR TITLE
Add C/C++ link option utility

### DIFF
--- a/quickrun2.el
+++ b/quickrun2.el
@@ -341,8 +341,12 @@
   (with-temp-buffer
     (insert-file-contents file)
     (goto-char (point-min))
-    (when (re-search-forward "^#\\s-*include\\s-*<\\(?:pthread\\.h\\|thread>\\)"nil t)
-      (list "-lpthread"))))
+    (let (link-flags)
+      (when (re-search-forward "^#\\s-*include\\s-*<\\(?:pthread\\.h\\|thread>\\)"nil t)
+        (push "-lpthread" link-flags))
+      (when (re-search-forward "^#\\s-*include\\s-*<\\(?:math\\.h\\|cmath>\\)"nil t)
+        (push "-lm" link-flags))
+      link-flags)))
 
 ;;
 ;; Language Settings


### PR DESCRIPTION
If the C/C++ files includes thread header, then append `-lpthread` flag